### PR TITLE
clean: replace unknown types with corresponding types

### DIFF
--- a/examples/src/__tests__/Component.test.ts
+++ b/examples/src/__tests__/Component.test.ts
@@ -11,19 +11,19 @@ test("should render", () => {
 // Note: This is as an async test as we are using `fireEvent`
 test('count increments when button is clicked', async () => {
   const results = render(App, { props: { name: "world" } });
-  const button = results.getByText('count: 0');
+  const button = results.getByText('add count: 0');
 
   // Using await when firing events is unique to the svelte testing library because
   // we have to wait for the next `tick` so that Svelte flushes all pending state changes.
   await fireEvent.click(button);
 
-  expect(button).toHaveTextContent('count: 1');
+  expect(button).toHaveTextContent('add count: 1');
 })
 
 
 test('listen custom event', async () => {
   const results = render(App, { props: { name: "world" } });
-  const button = results.getByText('count: 0');
+  const button = results.getByText('add count: 0');
 
   results.component.$on('someEvent', e=>{
     expect(e.detail).toBe(1);

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -1,13 +1,6 @@
-const defaultWrapperProps = {
+const resolveWrapperProps = (wrapperProps?: WrapperProps) => ({
     element: "div",
     id: "svelte-wrapper",
-};
-
-const resolveWrapperProps = (wrapperProps?: WrapperProps) => {
-    if (!wrapperProps) {
-        return defaultWrapperProps;
-    } else {
-        return Object.assign({}, defaultWrapperProps, wrapperProps);
-    }
-};
+    ...wrapperProps
+});
 export default resolveWrapperProps

--- a/packages/core/src/types/index.d.ts
+++ b/packages/core/src/types/index.d.ts
@@ -1,26 +1,11 @@
 interface ComponentOptions {
   target: HTMLElement | null;
-  anchor?: HTMLElement | null;
-  props?: {};
-  hydrate?: boolean;
-  intro?: boolean;
+  anchor: HTMLElement | null;
 }
 
-interface SvelteComponent {
-  new (options: ComponentOptions): any;
-  $$: any;
-  // client-side methods
-  $set(props: {}): void;
-  $on(event: string, callback: (event: CustomEvent) => void): void;
-  $destroy(): void;
+type SvelteComponent = import('svelte').SvelteComponent;
 
-  // server-side methods
-  render(props?: {}): {
-    html: string;
-    css: { code: string; map: string | null };
-    head?: string;
-  };
-}
+type SvelteComponentConstructor = new(ComponentOptions) => SvelteComponent;
 
 type WrapperProps = {
   element?: string | FunctionComponent<{}> | ComponentClass<{}, any>;


### PR DESCRIPTION
This PR removes every `as unknown as SvelteComponent` from the code, replacing them with their corresponding types.